### PR TITLE
Rename app to grabby-api and limit logging to API requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,14 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o mockhub ./cmd/mockhub
+RUN CGO_ENABLED=0 GOOS=linux go build -o grabby-api ./cmd/grabby-api
 
 FROM alpine:3.19
 WORKDIR /app
-COPY --from=build /src/mockhub ./mockhub
+COPY --from=build /src/grabby-api ./grabby-api
 COPY --from=build /src/examples/frontend ./examples/frontend
 COPY --from=build /src/internal/rest/openapi.yaml ./internal/rest/openapi.yaml
 EXPOSE 3002 8082
 ENV API_PORT=3002
 ENV UI_PORT=8082
-ENTRYPOINT ["/app/mockhub"]
+ENTRYPOINT ["/app/grabby-api"]

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,19 @@ SHELL := /bin/bash
 .PHONY: build run test docker-build docker-run import-defs
 
 build:
-	go build ./cmd/mockhub
+go build ./cmd/grabby-api
 
 run:
-	go run ./cmd/mockhub
+go run ./cmd/grabby-api
 
 test:
         go test ./...
 
 docker-build:
-        docker build -t mockhub .
+docker build -t grabby-api .
 
 docker-run: docker-build
-        docker run --rm -p 3002:3002 -p 8082:8082 mockhub
+docker run --rm -p 3002:3002 -p 8082:8082 grabby-api
 
 import-defs:
         scripts/import-defs.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MockHub
+# Grabby API
 
-MockHub is a local mock server for DataHub APIs. It serves canned responses for GraphQL and REST endpoints and allows toggling scenarios via request headers.
+Grabby API is a local mock server for DataHub APIs. It serves canned responses for GraphQL and REST endpoints and allows toggling scenarios via request headers.
 
 ## Running
 
@@ -18,7 +18,7 @@ make docker-build
 make docker-run
 ```
 
-Environment variables can be passed with `-e`, for example `docker run -e API_PORT=3002 -e UI_PORT=8082 -p 3002:3002 -p 8082:8082 mockhub`.
+Environment variables can be passed with `-e`, for example `docker run -e API_PORT=3002 -e UI_PORT=8082 -p 3002:3002 -p 8082:8082 grabby-api`.
 
 - GraphQL endpoint: `POST http://localhost:3002/api/graphql`
 - GraphiQL UI: `http://localhost:8082/graphiql`

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,6 +1,6 @@
 # Usage Guide
 
-This guide shows how to interact with MockHub's mocked DataHub APIs.
+This guide shows how to interact with Grabby API's mocked DataHub APIs.
 
 ## Prerequisites
 * Go 1.21+

--- a/cmd/grabby-api/main.go
+++ b/cmd/grabby-api/main.go
@@ -4,9 +4,9 @@ package main
 import (
 	"log"
 
-	"github.com/example/mockhub/internal/graphql"
-	"github.com/example/mockhub/internal/httpserver"
-	"github.com/example/mockhub/internal/rest"
+	"github.com/example/grabby-api/internal/graphql"
+	"github.com/example/grabby-api/internal/httpserver"
+	"github.com/example/grabby-api/internal/rest"
 )
 
 func main() {

--- a/examples/frontend/index.html
+++ b/examples/frontend/index.html
@@ -3,10 +3,10 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>MockHub Frontend</title>
+  <title>Grabby API Frontend</title>
 </head>
 <body>
-  <h1>MockHub Tester</h1>
+  <h1>Grabby API Tester</h1>
   <div>
     <label>Method:
       <select id="method">

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/example/mockhub
+module github.com/example/grabby-api
 
 go 1.21
 

--- a/internal/graphql/handler.go
+++ b/internal/graphql/handler.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/example/mockhub/pkg/httputil"
+	"github.com/example/grabby-api/pkg/httputil"
 )
 
 // request represents incoming GraphQL request.

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -11,9 +11,9 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
-	"github.com/example/mockhub/internal/graphql"
-	"github.com/example/mockhub/internal/rest"
-	"github.com/example/mockhub/pkg/httputil"
+	"github.com/example/grabby-api/internal/graphql"
+	"github.com/example/grabby-api/internal/rest"
+	"github.com/example/grabby-api/pkg/httputil"
 )
 
 // NewAPIServer configures the backend API server.
@@ -69,7 +69,6 @@ func NewUIServer() *http.Server {
 	logger := log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 
 	r := chi.NewRouter()
-	r.Use(httputil.RequestLogger(logger))
 	r.Use(httputil.Recoverer(logger))
 
 	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })

--- a/internal/rest/openapi.yaml
+++ b/internal/rest/openapi.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024. Licensed under the MIT License.
 openapi: 3.0.0
 info:
-  title: MockHub REST API
+  title: Grabby API
   version: 1.0.0
 servers:
   - url: http://localhost:3002

--- a/internal/rest/register.go
+++ b/internal/rest/register.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/example/mockhub/pkg/httputil"
+	"github.com/example/grabby-api/pkg/httputil"
 )
 
 var restMocks = map[string]map[string]map[string]interface{}{}

--- a/pkg/httputil/middleware.go
+++ b/pkg/httputil/middleware.go
@@ -12,6 +12,10 @@ import (
 func RequestLogger(logger zerolog.Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/healthz" || r.URL.Path == "/readyz" {
+				next.ServeHTTP(w, r)
+				return
+			}
 			start := time.Now()
 			scenario := ScenarioFromHeader(r)
 			ww := &responseWriter{ResponseWriter: w, status: 200}


### PR DESCRIPTION
## Summary
- rename project and binary to `grabby-api`
- limit request logging to API server and skip health checks
- update docs and examples with new name

## Testing
- `go build ./cmd/grabby-api`
- `go test ./...`
- `curl -s http://localhost:8082/swagger | head -n 5`
- `curl -s -H 'Content-Type: application/json' -d '{"query":"query search{search{start total}}","operationName":"search"}' http://localhost:3002/api/graphql`


------
https://chatgpt.com/codex/tasks/task_e_689f608f28e083308f2543cad74811f6